### PR TITLE
Changed the startDate format away from a string and to a parameterize…

### DIFF
--- a/src/components/CovidBotCounter.vue
+++ b/src/components/CovidBotCounter.vue
@@ -55,7 +55,7 @@ export default {
   props: {},
   data: function () {
     return {
-      startDate: new Date("5-19-2020"),
+      startDate: new Date(2020, 4, 19),
       todaysDate: new Date(),
       statusTaskMinutes: 30,
       statsuDaysElapsed: 0,

--- a/src/components/ExpenseBotCounter.vue
+++ b/src/components/ExpenseBotCounter.vue
@@ -48,7 +48,7 @@ export default {
   props: {},
   data: function () {
     return {
-      startDate: new Date("9-01-2020"),
+      startDate: new Date(2020, 8, 1),
       todaysDate: new Date(),
       expenseTaskMinutes: 20,
       expenseMinutesElapsed: 0,


### PR DESCRIPTION
…d date value due to issues with Safari.

Original code used a string to create the new Date value:

`new Date("5-19-2020")`

And this was causing issues with Safari. The number would come out as `NaN` Change was made to both components to use better (non-string) format for date creation.

`new Date(2020, 4, 19)`

(Date is zero based index so changed the `5` to a `4`)



